### PR TITLE
Support for adding/removing files with patches.

### DIFF
--- a/src/test/java/codechicken/diffpatch/test/PatchOperationTests.java
+++ b/src/test/java/codechicken/diffpatch/test/PatchOperationTests.java
@@ -7,7 +7,6 @@ import codechicken.diffpatch.util.archiver.ArchiveFormat;
 import codechicken.diffpatch.util.archiver.ArchiveReader;
 import codechicken.diffpatch.util.archiver.ArchiveWriter;
 import net.covers1624.quack.io.IOUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -17,8 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by covers1624 on 11/2/21.
@@ -290,22 +288,22 @@ public class PatchOperationTests {
                 .patchesPath(patches)
                 .build()
                 .operate();
-        assertEquals(0, result.exit);
-        assertTrue(Files.notExists(src.resolve("A.txt")));
-        assertTrue(Files.notExists(src.resolve("B.txt")));
+
+        assertAll(
+                () -> assertEquals(0, result.exit),
+                () -> assertTrue(Files.notExists(src.resolve("A.txt"))),
+                () -> assertTrue(Files.notExists(src.resolve("B.txt")))
+        );
     }
 
     @Test
     public void testFolderToFolderCreation() throws Throwable {
         Path tempDir = Files.createTempDirectory("dir_test");
         tempDir.toFile().deleteOnExit();
-
         Path orig = tempDir.resolve("orig");
         Files.createDirectories(orig);
-
         Path src = tempDir.resolve("src");
         Path patches = tempDir.resolve("patches");
-
         copyResource("/data/patches/CreateA.txt.patch", patches.resolve("A.txt.patch"));
         copyResource("/data/patches/CreateB.txt.patch", patches.resolve("B.txt.patch"));
         CliOperation.Result<PatchOperation.PatchesSummary> result = PatchOperation.builder()
@@ -318,7 +316,7 @@ public class PatchOperationTests {
                 .build()
                 .operate();
 
-        Assertions.assertAll(
+        assertAll(
                 () -> assertEquals(0, result.exit),
                 () -> assertTrue(Files.exists(src.resolve("A.txt"))),
                 () -> assertTrue(Files.exists(src.resolve("B.txt")))

--- a/src/test/java/codechicken/diffpatch/test/PatchOperationTests.java
+++ b/src/test/java/codechicken/diffpatch/test/PatchOperationTests.java
@@ -7,6 +7,7 @@ import codechicken.diffpatch.util.archiver.ArchiveFormat;
 import codechicken.diffpatch.util.archiver.ArchiveReader;
 import codechicken.diffpatch.util.archiver.ArchiveWriter;
 import net.covers1624.quack.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -267,6 +268,61 @@ public class PatchOperationTests {
                 .operate();
         assertEquals(0, result.exit);
         assertTrue(Files.exists(src.resolve("PatchFile.java")));
+    }
+
+    @Test
+    public void testFolderToFolderDeletion() throws Throwable {
+        Path tempDir = Files.createTempDirectory("dir_test");
+        tempDir.toFile().deleteOnExit();
+        Path orig = tempDir.resolve("orig");
+        Path src = tempDir.resolve("src");
+        Path patches = tempDir.resolve("patches");
+        copyResource("/data/orig/A.txt", orig.resolve("A.txt"));
+        copyResource("/data/orig/B.txt", orig.resolve("B.txt"));
+        copyResource("/data/patches/DeleteA.txt.patch", patches.resolve("A.txt.patch"));
+        copyResource("/data/patches/DeleteB.txt.patch", patches.resolve("B.txt.patch"));
+        CliOperation.Result<PatchOperation.PatchesSummary> result = PatchOperation.builder()
+                .logTo(System.out)
+                .level(LogLevel.ALL)
+                .summary(true)
+                .basePath(orig)
+                .outputPath(src)
+                .patchesPath(patches)
+                .build()
+                .operate();
+        assertEquals(0, result.exit);
+        assertTrue(Files.notExists(src.resolve("A.txt")));
+        assertTrue(Files.notExists(src.resolve("B.txt")));
+    }
+
+    @Test
+    public void testFolderToFolderCreation() throws Throwable {
+        Path tempDir = Files.createTempDirectory("dir_test");
+        tempDir.toFile().deleteOnExit();
+
+        Path orig = tempDir.resolve("orig");
+        Files.createDirectories(orig);
+
+        Path src = tempDir.resolve("src");
+        Path patches = tempDir.resolve("patches");
+
+        copyResource("/data/patches/CreateA.txt.patch", patches.resolve("A.txt.patch"));
+        copyResource("/data/patches/CreateB.txt.patch", patches.resolve("B.txt.patch"));
+        CliOperation.Result<PatchOperation.PatchesSummary> result = PatchOperation.builder()
+                .logTo(System.out)
+                .level(LogLevel.ALL)
+                .summary(true)
+                .basePath(orig)
+                .outputPath(src)
+                .patchesPath(patches)
+                .build()
+                .operate();
+
+        Assertions.assertAll(
+                () -> assertEquals(0, result.exit),
+                () -> assertTrue(Files.exists(src.resolve("A.txt"))),
+                () -> assertTrue(Files.exists(src.resolve("B.txt")))
+        );
     }
 
     private static void copyResource(String resource, Path to) throws IOException {

--- a/src/test/resources/data/orig/A.txt
+++ b/src/test/resources/data/orig/A.txt
@@ -1,0 +1,1 @@
+Example Contents A

--- a/src/test/resources/data/orig/B.txt
+++ b/src/test/resources/data/orig/B.txt
@@ -1,0 +1,1 @@
+Example Contents B

--- a/src/test/resources/data/patches/CreateA.txt.patch
+++ b/src/test/resources/data/patches/CreateA.txt.patch
@@ -1,0 +1,4 @@
+--- /dev/null
++++ b/A.txt
+@@ -1,0 +1,1 @@
++Example Contents A

--- a/src/test/resources/data/patches/CreateB.txt.patch
+++ b/src/test/resources/data/patches/CreateB.txt.patch
@@ -1,0 +1,4 @@
+--- /dev/null
++++ b/B.txt
+@@ -1,0 +1,1 @@
++Example Contents B

--- a/src/test/resources/data/patches/DeleteA.txt.patch
+++ b/src/test/resources/data/patches/DeleteA.txt.patch
@@ -1,0 +1,4 @@
+--- a/A.txt
++++ /dev/null
+@@ -1,1 +1,0 @@
+-Example Contents A

--- a/src/test/resources/data/patches/DeleteB.txt.patch
+++ b/src/test/resources/data/patches/DeleteB.txt.patch
@@ -1,0 +1,4 @@
+--- a/B.txt
++++ /dev/null
+@@ -1,1 +1,0 @@
+-Example Contents B


### PR DESCRIPTION
Adds support for `PatchOperation` to apply complete add/remove patches.

`DiffOperation` has already had this support since it was written. This was likely just missed when writing it initially.

Fixes #4 