### PR TITLE
feat: add emptyOutput and ignorePrefixes options to PatchOperation

### DIFF
--- a/src/main/java/codechicken/diffpatch/cli/DiffOperation.java
+++ b/src/main/java/codechicken/diffpatch/cli/DiffOperation.java
@@ -14,13 +14,13 @@ import net.covers1624.quack.util.SneakyUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
 
 import static codechicken.diffpatch.util.LogLevel.*;
+import static codechicken.diffpatch.util.Utils.filterPrefixed;
 import static codechicken.diffpatch.util.Utils.indexChildren;
 
 /**
@@ -305,21 +305,6 @@ public class DiffOperation extends CliOperation<DiffOperation.DiffSummary> {
         log(this.summary ? INFO : DEBUG, "%s -> %s\n %d Added.\n %d Removed.", aName, bName, added, removed);
 
         return patchFile.toLines(autoHeader);
-    }
-
-    private static Set<String> filterPrefixed(Set<String> toFilter, String[] filters) {
-        if (filters.length == 0) return toFilter;
-
-        return FastStream.of(toFilter)
-                .filterNot(e -> {
-                    for (String s : filters) {
-                        if (e.startsWith(s)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                })
-                .toSet();
     }
 
     public static class DiffSummary {

--- a/src/main/java/codechicken/diffpatch/cli/PatchOperation.java
+++ b/src/main/java/codechicken/diffpatch/cli/PatchOperation.java
@@ -255,7 +255,8 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
                 }
             }
         } else {
-            if (!basePath.toPath().equals(outputPath.toPath()) && Files.exists(outputPath.toPath())) {
+            boolean isInPlaceOperation = basePath.getType().isPath() && basePath.toPath().equals(outputPath.toPath());
+            if (!isInPlaceOperation && Files.exists(outputPath.toPath())) {
                 Utils.deleteFolder(outputPath.toPath());
             }
             for (Map.Entry<String, CollectedEntry> entry : outputCollector.get().entrySet()) {

--- a/src/main/java/codechicken/diffpatch/cli/PatchOperation.java
+++ b/src/main/java/codechicken/diffpatch/cli/PatchOperation.java
@@ -46,10 +46,9 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
     private final PatchMode mode;
     private final String patchesPrefix;
     private final String lineEnding;
-    private final boolean emptyOutput;
     private final String[] ignorePrefixes;
 
-    private PatchOperation(PrintStream logger, LogLevel level, Consumer<PrintStream> helpCallback, boolean summary, InputPath basePath, InputPath patchesPath, String aPrefix, String bPrefix, OutputPath outputPath, OutputPath rejectsPath, float minFuzz, int maxOffset, PatchMode mode, String patchesPrefix, String lineEnding, boolean emptyOutput, String[] ignorePrefixes) {
+    private PatchOperation(PrintStream logger, LogLevel level, Consumer<PrintStream> helpCallback, boolean summary, InputPath basePath, InputPath patchesPath, String aPrefix, String bPrefix, OutputPath outputPath, OutputPath rejectsPath, float minFuzz, int maxOffset, PatchMode mode, String patchesPrefix, String lineEnding, String[] ignorePrefixes) {
         super(logger, level, helpCallback);
         this.summary = summary;
         this.basePath = basePath;
@@ -63,7 +62,6 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
         this.mode = mode;
         this.patchesPrefix = patchesPrefix;
         this.lineEnding = lineEnding;
-        this.emptyOutput = emptyOutput;
         this.ignorePrefixes = ignorePrefixes;
     }
 
@@ -257,7 +255,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
                 }
             }
         } else {
-            if (emptyOutput && Files.exists(outputPath.toPath())) {
+            if (!basePath.toPath().equals(outputPath.toPath()) && Files.exists(outputPath.toPath())) {
                 Utils.deleteFolder(outputPath.toPath());
             }
             for (Map.Entry<String, CollectedEntry> entry : outputCollector.get().entrySet()) {
@@ -540,7 +538,6 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
         private String aPrefix = "a/";
         private String bPrefix = "b/";
         private String lineEnding = System.lineSeparator();
-        private boolean emptyOutput = true;
 
         private final List<String> ignorePrefixes = new LinkedList<>();
 
@@ -676,11 +673,6 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
             return this;
         }
 
-        public Builder emptyOutput(boolean emptyOutput) {
-            this.emptyOutput = emptyOutput;
-            return this;
-        }
-
         public Builder ignorePrefix(String prefix) {
             ignorePrefixes.add(prefix);
             return this;
@@ -696,7 +688,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
             if (outputPath == null) {
                 throw new IllegalStateException("output not set.");
             }
-            return new PatchOperation(logger, level, helpCallback, summary, basePath, patchesPath, aPrefix, bPrefix, outputPath, rejectsPath, minFuzz, maxOffset, mode, patchesPrefix, lineEnding, emptyOutput, ignorePrefixes.toArray(new String[0]));
+            return new PatchOperation(logger, level, helpCallback, summary, basePath, patchesPath, aPrefix, bPrefix, outputPath, rejectsPath, minFuzz, maxOffset, mode, patchesPrefix, lineEnding, ignorePrefixes.toArray(new String[0]));
         }
 
     }

--- a/src/main/java/codechicken/diffpatch/util/Utils.java
+++ b/src/main/java/codechicken/diffpatch/util/Utils.java
@@ -1,5 +1,6 @@
 package codechicken.diffpatch.util;
 
+import net.covers1624.quack.collection.FastStream;
 import net.covers1624.quack.util.SneakyUtils;
 
 import java.io.IOException;
@@ -7,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,5 +44,20 @@ public class Utils {
             return stream.filter(Files::isRegularFile)
                     .collect(Collectors.toMap(e -> stripStart('/', finalToIndex.relativize(e).toString().replace("\\", "/")), Function.identity()));
         }
+    }
+
+    public static Set<String> filterPrefixed(Set<String> toFilter, String[] filters) {
+        if (filters.length == 0) return toFilter;
+
+        return FastStream.of(toFilter)
+                .filterNot(e -> {
+                    for (String s : filters) {
+                        if (e.startsWith(s)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .toSet();
     }
 }


### PR DESCRIPTION
ignorePrefixes already exists on DiffOperation but is useful on patch too, to prevent copying of non modified files.
emptyOutput on DiffOperation allows working in scenarios where input = output, where you want to patch in place. its set to true by default (to replicate the current behavior) but can be toggled off.