### PR TITLE
Add options for setting the a/b path prefix using the CLI

### DIFF
--- a/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
+++ b/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
@@ -69,6 +69,14 @@ public class DiffPatchCli {
         OptionSpec<ArchiveFormat> baseArchiveOpt = parser.acceptsAll(asList("B", "archive-base"), "Treat the base path as an archive.")
                 .withRequiredArg()
                 .withValuesConvertedBy(new ArchiveFormatValueConverter());
+        OptionSpec<String> basePathPrefixOpt = parser.acceptsAll(asList("base-path-prefix"), "The prefix to assume for paths of base files.")
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("a/");
+        OptionSpec<String> modifiedPathPrefixOpt = parser.acceptsAll(asList("modified-path-prefix"), "The prefix to assume for paths of modified files.")
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("b/");
 
         //Diff specific
         OptionSpec<Void> doDiffOpt = parser.acceptsAll(asList("d", "diff"), "Does a Diff operation.");
@@ -118,16 +126,6 @@ public class DiffPatchCli {
                 .availableIf(doPatchOpt)
                 .withRequiredArg()
                 .withValuesConvertedBy(new ArchiveFormatValueConverter());
-        OptionSpec<String> stripBasePrefixOpt = parser.acceptsAll(asList("strip-base-prefix"), "The prefix to strip from paths of base files in the patch files.")
-                .availableIf(doPatchOpt)
-                .withRequiredArg()
-                .ofType(String.class)
-                .defaultsTo("a/");
-        OptionSpec<String> stripModifiedPrefixOpt = parser.acceptsAll(asList("strip-modified-prefix"), "The prefix to strip from paths of modified files in the patch files.")
-                .availableIf(doPatchOpt)
-                .withRequiredArg()
-                .ofType(String.class)
-                .defaultsTo("b/");
         OptionSet optSet = parser.parse(args);
         if (optSet.has(helpOpt)) {
             parser.printHelpOn(logger);
@@ -156,6 +154,9 @@ public class DiffPatchCli {
             ArchiveFormat aFormat = detectFormat(optSet.valueOf(baseArchiveOpt), aPath);
             ArchiveFormat bFormat = detectFormat(optSet.valueOf(modifiedArchiveOpt), bPath);
             ArchiveFormat outputFormat = detectFormat(optSet.valueOf(archiveOpt), outputPath);
+
+            String basePathPrefix = optSet.valueOf(basePathPrefixOpt);
+            String modifiedPathPrefix = optSet.valueOf(modifiedPathPrefixOpt);
 
             Output output;
             if (outputFormat != null) {
@@ -189,6 +190,8 @@ public class DiffPatchCli {
                     .summary(summary)
                     .autoHeader(optSet.has(autoHeaderOpt))
                     .context(optSet.valueOf(contextOpt))
+                    .aPrefix(basePathPrefix)
+                    .bPrefix(modifiedPathPrefix)
                     .build();
         }
         if (optSet.has(doPatchOpt)) {
@@ -200,8 +203,8 @@ public class DiffPatchCli {
             ArchiveFormat patchesFormat = detectFormat(optSet.valueOf(patchesArchiveOpt), patches);
             ArchiveFormat outputFormat = detectFormat(optSet.valueOf(archiveOpt), outputPath);
             ArchiveFormat rejectsFormat = detectFormat(optSet.valueOf(rejectArchiveOpt), rejectsPath);
-            String stripBasePrefix = optSet.valueOf(stripBasePrefixOpt);
-            String stripModifiedPrefix = optSet.valueOf(stripModifiedPrefixOpt);
+            String basePathPrefix = optSet.valueOf(basePathPrefixOpt);
+            String modifiedPathPrefix = optSet.valueOf(modifiedPathPrefixOpt);
 
             Input baseInput;
             if (baseFormat != null) {
@@ -245,8 +248,8 @@ public class DiffPatchCli {
                     .maxOffset(optSet.valueOf(offsetOpt))
                     .mode(optSet.valueOf(modeOpt))
                     .patchesPrefix(optSet.valueOf(patchPrefix))
-                    .aPrefix(stripBasePrefix)
-                    .bPrefix(stripModifiedPrefix)
+                    .aPrefix(basePathPrefix)
+                    .bPrefix(modifiedPathPrefix)
                     .build();
         }
 

--- a/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
+++ b/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
@@ -16,7 +16,6 @@ import joptsimple.OptionSpec;
 import joptsimple.util.EnumConverter;
 import joptsimple.util.PathConverter;
 import net.covers1624.quack.util.SneakyUtils;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -119,7 +118,16 @@ public class DiffPatchCli {
                 .availableIf(doPatchOpt)
                 .withRequiredArg()
                 .withValuesConvertedBy(new ArchiveFormatValueConverter());
-
+        OptionSpec<String> stripBasePrefixOpt = parser.acceptsAll(asList("strip-base-prefix"), "The prefix to strip from paths of base files in the patch files.")
+                .availableIf(doPatchOpt)
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("a/");
+        OptionSpec<String> stripModifiedPrefixOpt = parser.acceptsAll(asList("strip-modified-prefix"), "The prefix to strip from paths of modified files in the patch files.")
+                .availableIf(doPatchOpt)
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("b/");
         OptionSet optSet = parser.parse(args);
         if (optSet.has(helpOpt)) {
             parser.printHelpOn(logger);
@@ -192,6 +200,8 @@ public class DiffPatchCli {
             ArchiveFormat patchesFormat = detectFormat(optSet.valueOf(patchesArchiveOpt), patches);
             ArchiveFormat outputFormat = detectFormat(optSet.valueOf(archiveOpt), outputPath);
             ArchiveFormat rejectsFormat = detectFormat(optSet.valueOf(rejectArchiveOpt), rejectsPath);
+            String stripBasePrefix = optSet.valueOf(stripBasePrefixOpt);
+            String stripModifiedPrefix = optSet.valueOf(stripModifiedPrefixOpt);
 
             Input baseInput;
             if (baseFormat != null) {
@@ -235,6 +245,8 @@ public class DiffPatchCli {
                     .maxOffset(optSet.valueOf(offsetOpt))
                     .mode(optSet.valueOf(modeOpt))
                     .patchesPrefix(optSet.valueOf(patchPrefix))
+                    .aPrefix(stripBasePrefix)
+                    .bPrefix(stripModifiedPrefix)
                     .build();
         }
 

--- a/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
+++ b/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
@@ -126,6 +126,7 @@ public class DiffPatchCli {
                 .availableIf(doPatchOpt)
                 .withRequiredArg()
                 .withValuesConvertedBy(new ArchiveFormatValueConverter());
+
         OptionSet optSet = parser.parse(args);
         if (optSet.has(helpOpt)) {
             parser.printHelpOn(logger);

--- a/src/test/java/io/codechicken/diffpatch/cli/DiffPatchCliTests.java
+++ b/src/test/java/io/codechicken/diffpatch/cli/DiffPatchCliTests.java
@@ -3,7 +3,6 @@ package io.codechicken.diffpatch.cli;
 import io.codechicken.diffpatch.diff.Differ;
 import io.codechicken.diffpatch.match.FuzzyLineMatcher;
 import io.codechicken.diffpatch.test.TestBase;
-import io.codechicken.diffpatch.util.ConsumingOutputStream;
 import io.codechicken.diffpatch.util.Input;
 import io.codechicken.diffpatch.util.Output;
 import io.codechicken.diffpatch.util.PatchMode;
@@ -82,14 +81,14 @@ public class DiffPatchCliTests extends TestBase {
     @Test
     public void testDiffOptions() throws IOException {
         List<String> help = new ArrayList<>();
-        DiffOperation op = parse(help, "--diff", "--auto-header", "--context", "32", "--summary", "./a", "./b");
+        DiffOperation op = parse(help, "--diff", "--auto-header", "--context", "32", "--base-path-prefix", "base/", "--modified-path-prefix", "modified/", "--summary", "./a", "./b");
         assertTrue(help.isEmpty());
         assertNotNull(op);
         assertTrue(op.summary);
         assertTrue(op.baseInput instanceof Input.SingleInput.FromPath);
         assertTrue(op.changedInput instanceof Input.SingleInput.FromPath);
-        assertEquals("a/", op.aPrefix);
-        assertEquals("b/", op.bPrefix);
+        assertEquals("base/", op.aPrefix);
+        assertEquals("modified/", op.bPrefix);
         assertTrue(op.autoHeader);
         assertEquals(32, op.context);
         assertTrue(op.patchOutput instanceof Output.SingleOutput.ToStream);
@@ -231,14 +230,14 @@ public class DiffPatchCliTests extends TestBase {
     @Test
     public void testPatchOptions() throws IOException {
         List<String> help = new ArrayList<>();
-        PatchOperation op = parse(help, "--patch", "--summary", "--fuzz", "69.0", "-offset", "32", "--mode", "FUZZY", "--prefix", "asdf/", "./asdf/a", "./asdf/b");
+        PatchOperation op = parse(help, "--patch", "--summary", "--fuzz", "69.0", "-offset", "32", "--mode", "FUZZY", "--base-path-prefix", "base/", "--modified-path-prefix", "modified/", "--prefix", "asdf/", "./asdf/a", "./asdf/b");
         assertTrue(help.isEmpty());
         assertNotNull(op);
         assertTrue(op.summary);
         assertTrue(op.baseInput instanceof Input.SingleInput.FromPath);
         assertTrue(op.patchesInput instanceof Input.SingleInput.FromPath);
-        assertEquals("a/", op.aPrefix);
-        assertEquals("b/", op.bPrefix);
+        assertEquals("base/", op.aPrefix);
+        assertEquals("modified/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.SingleOutput.ToStream);
         assertNull(op.rejectsOutput);
         assertEquals(69.0F, op.minFuzz);


### PR DESCRIPTION
I am using DiffPatch CLI in NFRT (for easier fingerprinting the tool to include it in a cache-key).

I am trying to also use it for some older versions of Forge and noticed that in 1.12, the patch files don't use the `a/` and `b/` prefixes of newer patches. Options to change these in DiffPatch obviously exist, but aren't exposed via the CLI.
This PR adds those two options.