### PR TITLE
Fix empty file patches being generated

### DIFF
--- a/src/main/java/io/codechicken/diffpatch/diff/Differ.java
+++ b/src/main/java/io/codechicken/diffpatch/diff/Differ.java
@@ -43,11 +43,13 @@ public abstract class Differ {
     }
 
     public static List<Patch> makeFileAdded(List<String> lines) {
-        return Collections.singletonList(make(lines, Operation.INSERT));
+        Patch patch = make(lines, Operation.INSERT);
+        return patch.length2 == 0 ? Collections.emptyList() : Collections.singletonList(patch);
     }
 
     public static List<Patch> makeFileRemoved(List<String> lines) {
-        return Collections.singletonList(make(lines, Operation.DELETE));
+        Patch patch = make(lines, Operation.DELETE);
+        return patch.length1 == 0 ? Collections.emptyList() : Collections.singletonList(patch);
     }
 
     public static List<Patch> makePatches(List<Diff> diffs, int numContextLines, boolean collate) {

--- a/src/test/java/io/codechicken/diffpatch/cli/DiffOperationTests.java
+++ b/src/test/java/io/codechicken/diffpatch/cli/DiffOperationTests.java
@@ -6,6 +6,7 @@ import io.codechicken.diffpatch.util.Input;
 import io.codechicken.diffpatch.util.LogLevel;
 import io.codechicken.diffpatch.util.Output;
 import io.codechicken.diffpatch.util.archiver.ArchiveReader;
+import net.covers1624.quack.io.NullOutputStream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -152,5 +153,18 @@ public class DiffOperationTests extends TestBase {
         try (ArchiveReader ar = ZIP.createReader(new ByteArrayInputStream(output.toByteArray()))) {
             assertEquals(testResourceString("/patches/AToANoNewline.txt.patch"), new String(ar.getBytes("A.txt.patch"), StandardCharsets.UTF_8));
         }
+    }
+
+    @Test
+    public void testDiffEmpty() throws IOException {
+        CliOperation.Result<DiffOperation.DiffSummary> result = DiffOperation.builder()
+                .logTo(System.out)
+                .level(LogLevel.ALL)
+                .baseInput(Input.SingleInput.string(""))
+                .changedInput(Input.SingleInput.string(""))
+                .patchesOutput(Output.SingleOutput.pipe(NullOutputStream.INSTANCE))
+                .build()
+                .operate();
+        assertEquals(0, result.exit);
     }
 }


### PR DESCRIPTION
Before, when comparing empty files, an empty diff would be created.
This would cause generating an empty patch, like:
```diff
--- a/empty_file
+++ b/empty_file
@@ -1,0 +_,0 @@
```
<br>
As you can see here:

https://github.com/TheCBProject/DiffPatch/blob/204d393ee23f5cd4298f771c7b9157ee21eb3b62/src/main/java/io/codechicken/diffpatch/cli/DiffOperation.java#L216-L217
when `aLines.isEmpty()` (which in case of both files being empty is always true), it invokes `Differ.makeFileAdded`.

I added a check to `Differ.makeFileAdded` and `Differ.makeFileRemoved` (not sure if it's needed there, but just in case) that verifies if there were any actual changes to fix this issue.