### PR TITLE
Add an option for outputting reject files as patches.

### DIFF
--- a/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
+++ b/src/main/java/io/codechicken/diffpatch/cli/DiffPatchCli.java
@@ -107,6 +107,7 @@ public class DiffPatchCli {
                 .availableIf(doPatchOpt)
                 .withRequiredArg()
                 .withValuesConvertedBy(new ArchiveFormatValueConverter());
+        OptionSpec<Void> rejectAsPatches = parser.acceptsAll(asList("rejects-as-patches"), "Output rejected hunks as patch files, instead of a semi-custom format.");
         OptionSpec<Float> fuzzOpt = parser.acceptsAll(asList("f", "fuzz"), "The minimum fuzz match quality, anything lower will be treated as a failure.")
                 .availableIf(doPatchOpt)
                 .withRequiredArg()
@@ -222,6 +223,7 @@ public class DiffPatchCli {
                             rejectsPath,
                             null
                     ))
+                    .rejectsAsPatches(optSet.has(rejectAsPatches))
                     .minFuzz(optSet.valueOf(fuzzOpt))
                     .maxOffset(optSet.valueOf(offsetOpt))
                     .mode(optSet.valueOf(modeOpt))

--- a/src/main/java/io/codechicken/diffpatch/cli/PatchOperation.java
+++ b/src/main/java/io/codechicken/diffpatch/cli/PatchOperation.java
@@ -38,6 +38,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
     final String bPrefix;
     final Output patchedOutput;
     final @Nullable Output rejectsOutput;
+    final boolean rejectsAsPatches;
     final float minFuzz;
     final int maxOffset;
     final PatchMode mode;
@@ -45,7 +46,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
     final String lineEnding;
     final String[] ignorePrefixes;
 
-    private PatchOperation(PrintStream logger, LogLevel level, Consumer<PrintStream> helpCallback, boolean summary, Input baseInput, Input patchesInput, String aPrefix, String bPrefix, Output patchedOutput, @Nullable Output rejectsOutput, float minFuzz, int maxOffset, PatchMode mode, String patchesPrefix, String lineEnding, String[] ignorePrefixes) {
+    private PatchOperation(PrintStream logger, LogLevel level, Consumer<PrintStream> helpCallback, boolean summary, Input baseInput, Input patchesInput, String aPrefix, String bPrefix, Output patchedOutput, @Nullable Output rejectsOutput, boolean rejectsAsPatches, float minFuzz, int maxOffset, PatchMode mode, String patchesPrefix, String lineEnding, String[] ignorePrefixes) {
         super(logger, level, helpCallback);
         this.summary = summary;
         this.baseInput = baseInput;
@@ -54,6 +55,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
         this.bPrefix = bPrefix;
         this.patchedOutput = patchedOutput;
         this.rejectsOutput = rejectsOutput;
+        this.rejectsAsPatches = rejectsAsPatches;
         this.minFuzz = minFuzz;
         this.maxOffset = maxOffset;
         this.mode = mode;
@@ -236,7 +238,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
         Patcher patcher = new Patcher(patchFile, base, minFuzz, maxOffset);
         log(DEBUG, "Patching: " + baseName);
         List<Patcher.Result> results = patcher.patch(mode);
-        List<String> rejectLines = new ArrayList<>();
+        List<RejectedHunk> rejectedHunks = new ArrayList<>();
         boolean first = true;
         for (int i = 0; i < results.size(); i++) {
             Patcher.Result result = results.get(i);
@@ -264,17 +266,12 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
             }
 
             if (!result.success) {
-                if (!first) {
-                    rejectLines.add("");
-                } else if (!level.shouldLog(DEBUG)) { // Log the patch name as warn, only if its failed, and we haven't logged it already (top of this function.)
+                if (first && !level.shouldLog(DEBUG)) { // Log the patch name as warn, only if its failed, and we haven't logged it already (top of this function.)
                     log(WARN, "Patching: " + baseName);
                 }
                 log(WARN, " Hunk %d: %s", i, result.summary());
                 first = false;
-                rejectLines.add("++++ REJECTED HUNK: " + (i + 1));
-                rejectLines.add(result.patch.getHeader());
-                FastStream.of(result.patch.diffs).map(Diff::toString).forEach(rejectLines::add);
-                rejectLines.add("++++ END HUNK");
+                rejectedHunks.add(new RejectedHunk(i, result.patch));
             } else {
                 log(DEBUG, " Hunk %d: %s", i, result.summary());
             }
@@ -290,8 +287,23 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
             }
         }
         outputCollector.consume(baseName, lines);
-        if (!rejectLines.isEmpty()) {
-            rejectCollector.consume(patchFile.name + ".rej", rejectLines);
+
+        if (!rejectedHunks.isEmpty()) {
+            if (rejectsAsPatches) {
+                PatchFile rejects = new PatchFile(patchFile.name, patchFile.basePath, patchFile.patchedPath);
+                rejectedHunks.forEach(e -> rejects.patches.add(e.hunk));
+                rejectCollector.consume(baseName + ".rej.patch", rejects.toLines(false));
+            } else {
+                List<String> rejectLines = new ArrayList<>();
+                for (RejectedHunk r : rejectedHunks) {
+                    rejectLines.add("++++ REJECTED HUNK: " + (r.index + 1));
+                    rejectLines.add(r.hunk.getHeader());
+                    FastStream.of(r.hunk.diffs).map(Diff::toString).forEach(rejectLines::add);
+                    rejectLines.add("++++ END HUNK");
+                }
+
+                rejectCollector.consume(patchFile.name + ".rej", rejectLines);
+            }
             return false;
         }
         return true;
@@ -327,6 +339,17 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
     public static String bakePatch(PatchFile patchFile, String lineEnding) {
         List<String> lines = patchFile.toLines(false);
         return String.join(lineEnding, lines) + lineEnding;
+    }
+
+    // TODO record when J17+
+    private static class RejectedHunk {
+        public final int index;
+        public final Patch hunk;
+
+        private RejectedHunk(int index, Patch hunk) {
+            this.index = index;
+            this.hunk = hunk;
+        }
     }
 
     public static class PatchesSummary {
@@ -376,6 +399,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
         private @Nullable Input patchesInput;
         private @Nullable Output patchedOutput;
         private @Nullable Output rejectsOutput;
+        private boolean rejectsAsPatches = false;
         private float minFuzz = FuzzyLineMatcher.DEFAULT_MIN_MATCH_SCORE;
         private int maxOffset = FuzzyLineMatcher.MatchMatrix.DEFAULT_MAX_OFFSET;
         private PatchMode mode = PatchMode.EXACT;
@@ -448,6 +472,11 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
             return this;
         }
 
+        public Builder rejectsAsPatches(boolean rejectsAsPatches) {
+            this.rejectsAsPatches = rejectsAsPatches;
+            return this;
+        }
+
         public Builder minFuzz(float minFuzz) {
             this.minFuzz = minFuzz;
             return this;
@@ -483,7 +512,7 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
             if (patchesInput == null) throw new IllegalStateException("patchesInput is required.");
             if (patchedOutput == null) throw new IllegalStateException("patchedOutput is required.");
 
-            return new PatchOperation(logger, level, helpCallback, summary, baseInput, patchesInput, aPrefix, bPrefix, patchedOutput, rejectsOutput, minFuzz, maxOffset, mode, patchesPrefix, lineEnding, ignorePrefixes.toArray(new String[0]));
+            return new PatchOperation(logger, level, helpCallback, summary, baseInput, patchesInput, aPrefix, bPrefix, patchedOutput, rejectsOutput, rejectsAsPatches, minFuzz, maxOffset, mode, patchesPrefix, lineEnding, ignorePrefixes.toArray(new String[0]));
         }
     }
 }

--- a/src/main/java/io/codechicken/diffpatch/cli/PatchOperation.java
+++ b/src/main/java/io/codechicken/diffpatch/cli/PatchOperation.java
@@ -295,7 +295,9 @@ public class PatchOperation extends CliOperation<PatchOperation.PatchesSummary> 
                 rejectCollector.consume(baseName + ".rej.patch", rejects.toLines(false));
             } else {
                 List<String> rejectLines = new ArrayList<>();
-                for (RejectedHunk r : rejectedHunks) {
+                for (int i = 0; i < rejectedHunks.size(); i++) {
+                    if (i != 0) rejectLines.add(" ");
+                    RejectedHunk r = rejectedHunks.get(i);
                     rejectLines.add("++++ REJECTED HUNK: " + (r.index + 1));
                     rejectLines.add(r.hunk.getHeader());
                     FastStream.of(r.hunk.diffs).map(Diff::toString).forEach(rejectLines::add);

--- a/src/main/java/io/codechicken/diffpatch/util/PatchFile.java
+++ b/src/main/java/io/codechicken/diffpatch/util/PatchFile.java
@@ -22,6 +22,15 @@ public class PatchFile {
 
     public List<Patch> patches = new ArrayList<>();
 
+    public PatchFile() {
+    }
+
+    public PatchFile(@Nullable String name, @Nullable String basePath, @Nullable String patchedPath) {
+        this.name = name;
+        this.basePath = basePath;
+        this.patchedPath = patchedPath;
+    }
+
     public static PatchFile fromLines(String name, List<String> lines, boolean verifyHeaders) {
         PatchFile patchFile = new PatchFile();
         patchFile.name = name;

--- a/src/test/java/io/codechicken/diffpatch/cli/DiffPatchCliTests.java
+++ b/src/test/java/io/codechicken/diffpatch/cli/DiffPatchCliTests.java
@@ -219,6 +219,7 @@ public class DiffPatchCliTests extends TestBase {
         assertEquals("b/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.SingleOutput.ToStream);
         assertNull(op.rejectsOutput);
+        assertFalse(op.rejectsAsPatches);
         assertEquals(FuzzyLineMatcher.DEFAULT_MIN_MATCH_SCORE, op.minFuzz);
         assertEquals(FuzzyLineMatcher.MatchMatrix.DEFAULT_MAX_OFFSET, op.maxOffset);
         assertEquals(PatchMode.EXACT, op.mode);
@@ -230,7 +231,7 @@ public class DiffPatchCliTests extends TestBase {
     @Test
     public void testPatchOptions() throws IOException {
         List<String> help = new ArrayList<>();
-        PatchOperation op = parse(help, "--patch", "--summary", "--fuzz", "69.0", "-offset", "32", "--mode", "FUZZY", "--line-ending", "CR", "--base-path-prefix", "base/", "--modified-path-prefix", "modified/", "--prefix", "asdf/", "./asdf/a", "./asdf/b");
+        PatchOperation op = parse(help, "--patch", "--summary", "--rejects-as-patches", "--fuzz", "69.0", "-offset", "32", "--mode", "FUZZY", "--line-ending", "CR", "--base-path-prefix", "base/", "--modified-path-prefix", "modified/", "--prefix", "asdf/", "./asdf/a", "./asdf/b");
         assertTrue(help.isEmpty());
         assertNotNull(op);
         assertTrue(op.summary);
@@ -240,6 +241,7 @@ public class DiffPatchCliTests extends TestBase {
         assertEquals("modified/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.SingleOutput.ToStream);
         assertNull(op.rejectsOutput);
+        assertTrue(op.rejectsAsPatches);
         assertEquals(69.0F, op.minFuzz);
         assertEquals(32, op.maxOffset);
         assertEquals(PatchMode.FUZZY, op.mode);
@@ -278,6 +280,7 @@ public class DiffPatchCliTests extends TestBase {
         assertEquals("b/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.SingleOutput.ToPath);
         assertTrue(op.rejectsOutput instanceof Output.SingleOutput.ToPath);
+        assertFalse(op.rejectsAsPatches);
         assertEquals(FuzzyLineMatcher.DEFAULT_MIN_MATCH_SCORE, op.minFuzz);
         assertEquals(FuzzyLineMatcher.MatchMatrix.DEFAULT_MAX_OFFSET, op.maxOffset);
         assertEquals(PatchMode.EXACT, op.mode);
@@ -308,6 +311,7 @@ public class DiffPatchCliTests extends TestBase {
         assertEquals("b/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.SingleOutput.PathArchiveMultiOutput);
         assertTrue(op.rejectsOutput instanceof Output.SingleOutput.PathArchiveMultiOutput);
+        assertFalse(op.rejectsAsPatches);
         assertEquals(FuzzyLineMatcher.DEFAULT_MIN_MATCH_SCORE, op.minFuzz);
         assertEquals(FuzzyLineMatcher.MatchMatrix.DEFAULT_MAX_OFFSET, op.maxOffset);
         assertEquals(PatchMode.EXACT, op.mode);
@@ -334,6 +338,7 @@ public class DiffPatchCliTests extends TestBase {
         assertEquals("b/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.SingleOutput.PipeArchiveMultiOutput);
         assertTrue(op.rejectsOutput instanceof Output.SingleOutput.PathArchiveMultiOutput);
+        assertFalse(op.rejectsAsPatches);
         assertEquals(FuzzyLineMatcher.DEFAULT_MIN_MATCH_SCORE, op.minFuzz);
         assertEquals(FuzzyLineMatcher.MatchMatrix.DEFAULT_MAX_OFFSET, op.maxOffset);
         assertEquals(PatchMode.EXACT, op.mode);
@@ -360,6 +365,7 @@ public class DiffPatchCliTests extends TestBase {
         assertEquals("b/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.SingleOutput.PathArchiveMultiOutput);
         assertTrue(op.rejectsOutput instanceof Output.SingleOutput.PathArchiveMultiOutput);
+        assertFalse(op.rejectsAsPatches);
         assertEquals(FuzzyLineMatcher.DEFAULT_MIN_MATCH_SCORE, op.minFuzz);
         assertEquals(FuzzyLineMatcher.MatchMatrix.DEFAULT_MAX_OFFSET, op.maxOffset);
         assertEquals(PatchMode.EXACT, op.mode);
@@ -386,6 +392,7 @@ public class DiffPatchCliTests extends TestBase {
         assertEquals("b/", op.bPrefix);
         assertTrue(op.patchedOutput instanceof Output.FolderMultiOutput);
         assertTrue(op.rejectsOutput instanceof Output.FolderMultiOutput);
+        assertFalse(op.rejectsAsPatches);
         assertEquals(FuzzyLineMatcher.DEFAULT_MIN_MATCH_SCORE, op.minFuzz);
         assertEquals(FuzzyLineMatcher.MatchMatrix.DEFAULT_MAX_OFFSET, op.maxOffset);
         assertEquals(PatchMode.EXACT, op.mode);

--- a/src/test/java/io/codechicken/diffpatch/cli/PatchOperationTests.java
+++ b/src/test/java/io/codechicken/diffpatch/cli/PatchOperationTests.java
@@ -94,7 +94,7 @@ public class PatchOperationTests extends TestBase {
     }
 
     @Test
-    public void testPatchReject() throws IOException {
+    public void testPatchRejectLegacy() throws IOException {
         // We try and patch B with the A -> B patch.
         byte[] base = new ArchiveBuilder()
                 .put("A.txt", testResource("/files/B.txt"))
@@ -122,6 +122,39 @@ public class PatchOperationTests extends TestBase {
         }
         try (ArchiveReader ar = ZIP.createReader(new ByteArrayInputStream(rejects.toByteArray()))) {
             assertEquals(testResourceString("/rejects/ModifiedA.txt.patch.rej"), new String(ar.getBytes("A.txt.patch.rej"), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testPatchReject() throws IOException {
+        // We try and patch B with the A -> B patch.
+        byte[] base = new ArchiveBuilder()
+                .put("A.txt", testResource("/files/B.txt"))
+                .toBytes(ZIP);
+        byte[] patches = new ArchiveBuilder()
+                .put("A.txt.patch", testResource("/patches/ModifiedA.txt.patch"))
+                .toBytes(ZIP);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream rejects = new ByteArrayOutputStream();
+        CliOperation.Result<PatchOperation.PatchesSummary> result = PatchOperation.builder()
+                .logTo(System.out)
+                .level(LogLevel.ALL)
+                .baseInput(MultiInput.archive(ZIP, base))
+                .patchesInput(MultiInput.archive(ZIP, patches))
+                .rejectsOutput(MultiOutput.archive(ZIP, rejects))
+                .rejectsAsPatches(true)
+                .patchedOutput(MultiOutput.archive(ZIP, output))
+                .build()
+                .operate();
+
+        assertEquals(1, result.exit);
+        try (ArchiveReader ar = ZIP.createReader(new ByteArrayInputStream(output.toByteArray()))) {
+            // The 'A' file (which was B as input), should just be 'B' as we rejected the hunk.
+            assertEquals(testResourceString("/files/B.txt"), new String(ar.getBytes("A.txt"), StandardCharsets.UTF_8));
+        }
+        try (ArchiveReader ar = ZIP.createReader(new ByteArrayInputStream(rejects.toByteArray()))) {
+            assertEquals(testResourceString("/patches/ModifiedA.txt.patch"), new String(ar.getBytes("A.txt.rej.patch"), StandardCharsets.UTF_8));
         }
     }
 


### PR DESCRIPTION
Adds a new CLI option/builder argument for patching mode to output reject files as regular patch files.

I expect this to become the default with the option removed in the next major version of DiffPatch with breaking changes.